### PR TITLE
update to work with 0.14.5 (only vim normal mode though)

### DIFF
--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -13,9 +13,10 @@ export const activeVisualLine = ViewPlugin.fromClass(
     createObserver(view: EditorView) {
       const config = { attributes: true, childList: true, subtree: true },
         selectionLayer = view.dom.querySelector(".cm-selectionLayer"),
-        cursorLayer = view.dom.querySelector(".cm-cursorLayer"),
+        cursorLayer = view.dom.querySelector(".cm-vimCursorLayer"),
+        vimCursor = view.dom.querySelector(".cm-fat-cursor"),
         contentDOM = view.dom;
-      if (!selectionLayer || !cursorLayer) return;
+      if (!selectionLayer || !vimCursor) return;
       document.body.addClass("active-visual-line");
       this.highlightLayerEl = view.scrollDOM.createDiv("cm-highlightLayer");
       this.highlightLayerEl.ariaHidden = "true";
@@ -29,13 +30,13 @@ export const activeVisualLine = ViewPlugin.fromClass(
           let height: number, top: number;
           if (mutation.type === "childList") {
             let cursorEl = Array.from(mutation.addedNodes).find(
-              el => el instanceof HTMLElement && el.hasClass("cm-cursor-primary")
+              el => el instanceof HTMLElement && el.hasClass("cm-fat-cursor")
             ) as HTMLElement;
             if (cursorEl) {
               height = parseInt(cursorEl.style.height);
               top = parseInt(cursorEl.style.top);
             }
-          } else if (mutation.target instanceof HTMLElement && mutation.target.hasClass("cm-cursor-primary")) {
+          } else if (mutation.target instanceof HTMLElement && mutation.target.hasClass("cm-fat-cursor")) {
             height = parseInt(mutation.target.style.height);
             top = parseInt(mutation.target.style.top);
           }


### PR DESCRIPTION
since there is no `.cm-cursor` anymore, this plugin won't work with normal anymore. However, the element for the vim cursor still exists, so I updated the selectors (the only part of the code that I understand anyway 🙈 ) to make the plugin at least work within vim's normal mode.

it will not, however, work correctly with insert mode, since then there still is no element to target for the normal cursor.

---

unfortunately, this does not solve #2, since I could not figure out how to make the line highlight go away when not in normal mode. It should be rather straightforward:
- when there is no `.cm-fat-cursor` in the DOM anymore → remove line highlight
- when `.cm-far-cursor` re-appears in the DOM → re-apply line-highlight.